### PR TITLE
Added masked card number formatter.

### DIFF
--- a/CreditCardFormatter.xcodeproj/project.pbxproj
+++ b/CreditCardFormatter.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		65DE266023A2FD8700916E9C /* DinersClubInternationalCreditCardFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65DE265F23A2FD8700916E9C /* DinersClubInternationalCreditCardFormat.swift */; };
 		65DE266223A533B300916E9C /* DinersClubInternationalCreditCardFormatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65DE266123A533B300916E9C /* DinersClubInternationalCreditCardFormatTests.swift */; };
 		65DE34132351018400B9F313 /* UnknownCreditCardFormatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65DE34122351018400B9F313 /* UnknownCreditCardFormatTests.swift */; };
+		876A74802CE536A200B7BB5D /* CreditCardBrand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 876A747F2CE536A200B7BB5D /* CreditCardBrand.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -74,6 +75,7 @@
 		65DE265F23A2FD8700916E9C /* DinersClubInternationalCreditCardFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DinersClubInternationalCreditCardFormat.swift; sourceTree = "<group>"; };
 		65DE266123A533B300916E9C /* DinersClubInternationalCreditCardFormatTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DinersClubInternationalCreditCardFormatTests.swift; sourceTree = "<group>"; };
 		65DE34122351018400B9F313 /* UnknownCreditCardFormatTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnknownCreditCardFormatTests.swift; sourceTree = "<group>"; };
+		876A747F2CE536A200B7BB5D /* CreditCardBrand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreditCardBrand.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -181,8 +183,9 @@
 				65D0DD992399C7C300E6B465 /* DiscoverCreditCardFormat.swift */,
 				65DE265D23A2FBA900916E9C /* JCBCreditCardFormat.swift */,
 				658A37C32399B5F5001B79FE /* MasterCardCreditCardFormat.swift */,
-				65CCBE66234A2F0D0072B498 /* UnknownCreditCardFormat.swift */,
 				650342A82329201500F5E01C /* VISACreditCardFormat.swift */,
+				65CCBE66234A2F0D0072B498 /* UnknownCreditCardFormat.swift */,
+				876A747F2CE536A200B7BB5D /* CreditCardBrand.swift */,
 			);
 			path = Formats;
 			sourceTree = "<group>";
@@ -331,6 +334,7 @@
 				650342A6232849A000F5E01C /* CreditCardFormat.swift in Sources */,
 				65DE266023A2FD8700916E9C /* DinersClubInternationalCreditCardFormat.swift in Sources */,
 				658A37C42399B5F5001B79FE /* MasterCardCreditCardFormat.swift in Sources */,
+				876A74802CE536A200B7BB5D /* CreditCardBrand.swift in Sources */,
 				650342A92329201500F5E01C /* VISACreditCardFormat.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/CreditCardFormatter/CreditCardFormat.swift
+++ b/Sources/CreditCardFormatter/CreditCardFormat.swift
@@ -28,7 +28,7 @@ import Foundation
 
 public protocol CreditCardFormat {
     var blocks: [Int] { get }
-    var brand: String { get }
+    var brand: CreditCardBrand { get }
     func shouldFormat(_ string: String) -> Bool
     func isValid(_ string: String) -> Bool
 }

--- a/Sources/CreditCardFormatter/CreditCardFormat.swift
+++ b/Sources/CreditCardFormatter/CreditCardFormat.swift
@@ -29,6 +29,7 @@ import Foundation
 public protocol CreditCardFormat {
     var blocks: [Int] { get }
     var brand: CreditCardBrand { get }
+    var cvvLength: Int { get }
     func shouldFormat(_ string: String) -> Bool
     func isValid(_ string: String) -> Bool
 }

--- a/Sources/CreditCardFormatter/CreditCardFormatter.swift
+++ b/Sources/CreditCardFormatter/CreditCardFormatter.swift
@@ -89,6 +89,13 @@ public final class CreditCardFormatter {
         let formatter = selectFormatter(from: strippedString)
         return formatter.isValid(strippedString)
     }
+    
+    public func cvvCodeLength(from string: String) -> Int {
+        let strippedString = removeNonDecimalDigits(from: string)
+        let matchedFormatter = selectFormatter(from: strippedString)
+        let cvvLength = matchedFormatter.cvvLength
+        return cvvLength
+    }
 }
 
 extension String {

--- a/Sources/CreditCardFormatter/CreditCardFormatter.swift
+++ b/Sources/CreditCardFormatter/CreditCardFormatter.swift
@@ -68,6 +68,16 @@ public final class CreditCardFormatter {
         return formatter.formattedString(from: strippedString, delimiter: delimiter, repeatLastBlock: shouldRepeatLastBlock(for: formatter))
     }
     
+    public func formattedMaskedString(from string: String, maskCharacter: Character) -> String {
+        let maskedString = string.filter { $0.isWholeNumber || $0 == maskCharacter }
+        let formatter = selectFormatter(from: maskedString)
+        return formatter.formattedString(
+            from: maskedString,
+            delimiter: delimiter,
+            repeatLastBlock: shouldRepeatLastBlock(for: formatter)
+        )
+    }
+    
     public func brand(from string: String) -> String {
         let strippedString = removeNonDecimalDigits(from: string)
         let formatter = selectFormatter(from: strippedString)

--- a/Sources/CreditCardFormatter/CreditCardFormatter.swift
+++ b/Sources/CreditCardFormatter/CreditCardFormatter.swift
@@ -81,7 +81,7 @@ public final class CreditCardFormatter {
     public func brand(from string: String) -> String {
         let strippedString = removeNonDecimalDigits(from: string)
         let formatter = selectFormatter(from: strippedString)
-        return formatter.brand
+        return formatter.brand.rawValue
     }
 
     public func isValid(_ string: String) -> Bool {

--- a/Sources/CreditCardFormatter/Formats/AmericanExpressCreditCardFormat.swift
+++ b/Sources/CreditCardFormatter/Formats/AmericanExpressCreditCardFormat.swift
@@ -29,6 +29,7 @@ import Foundation
 public struct AmericanExpressCreditCardFormat: CreditCardFormat {
     public let blocks: [Int] = [4, 6, 5]
     public let brand: CreditCardBrand = .americanExpress
+    public let cvvLength: Int = 4
 
     public init() {}
 

--- a/Sources/CreditCardFormatter/Formats/AmericanExpressCreditCardFormat.swift
+++ b/Sources/CreditCardFormatter/Formats/AmericanExpressCreditCardFormat.swift
@@ -26,13 +26,9 @@
 
 import Foundation
 
-public extension CreditCardBrands {
-    static let americanExpress = "American Express"
-}
-
 public struct AmericanExpressCreditCardFormat: CreditCardFormat {
     public let blocks: [Int] = [4, 6, 5]
-    public let brand: String = CreditCardBrands.americanExpress
+    public let brand: CreditCardBrand = .americanExpress
 
     public init() {}
 

--- a/Sources/CreditCardFormatter/Formats/ChinaUnionPayCreditCardFormat.swift
+++ b/Sources/CreditCardFormatter/Formats/ChinaUnionPayCreditCardFormat.swift
@@ -29,7 +29,8 @@ import Foundation
 public struct ChinaUnionPayCreditCardFormat: CreditCardFormat {
     public let blocks: [Int] = [4, 4, 4, 4]
     public let brand: CreditCardBrand = .chinaUnionPay
-
+    public let cvvLength: Int = 3
+    
     private let maxLength = 19
     private let minLength = 13
 

--- a/Sources/CreditCardFormatter/Formats/ChinaUnionPayCreditCardFormat.swift
+++ b/Sources/CreditCardFormatter/Formats/ChinaUnionPayCreditCardFormat.swift
@@ -26,13 +26,9 @@
 
 import Foundation
 
-public extension CreditCardBrands {
-    static let chinaUnionPay = "China UnionPay"
-}
-
 public struct ChinaUnionPayCreditCardFormat: CreditCardFormat {
     public let blocks: [Int] = [4, 4, 4, 4]
-    public let brand: String = CreditCardBrands.chinaUnionPay
+    public let brand: CreditCardBrand = .chinaUnionPay
 
     private let maxLength = 19
     private let minLength = 13

--- a/Sources/CreditCardFormatter/Formats/CreditCardBrand.swift
+++ b/Sources/CreditCardFormatter/Formats/CreditCardBrand.swift
@@ -1,0 +1,20 @@
+//
+//  CreditCardBrands.swift
+//  CreditCardFormatter
+//
+//  Created by Egehan Kalayci (Dogus Teknoloji) on 13.11.2024.
+//  Copyright © 2024 Barbarity Apps. All rights reserved.
+//
+
+import Foundation
+
+public enum CreditCardBrand: String {
+    case americanExpress = "American Express"
+    case chinaUnionPay = "China UnionPay"
+    case dinersClubInternational = "Diners Club International"
+    case discover = "Discover"
+    case jcb = "JCB"
+    case masterCard = "MasterCard"
+    case visa = "Visa"
+    case unknown = "Unknown"
+}

--- a/Sources/CreditCardFormatter/Formats/DinersClubInternationalCreditCardFormat.swift
+++ b/Sources/CreditCardFormatter/Formats/DinersClubInternationalCreditCardFormat.swift
@@ -29,6 +29,7 @@ import Foundation
 public struct DinersClubInternationalCreditCardFormat: CreditCardFormat {
     public let blocks: [Int] = [4, 6, 4]
     public let brand: CreditCardBrand = .dinersClubInternational
+    public let cvvLength: Int = 3
     
     private let maxLength = 19
     private let minLength = 14

--- a/Sources/CreditCardFormatter/Formats/DinersClubInternationalCreditCardFormat.swift
+++ b/Sources/CreditCardFormatter/Formats/DinersClubInternationalCreditCardFormat.swift
@@ -26,13 +26,9 @@
 
 import Foundation
 
-public extension CreditCardBrands {
-    static let dinersClubInternational = "Diners Club International"
-}
-
 public struct DinersClubInternationalCreditCardFormat: CreditCardFormat {
     public let blocks: [Int] = [4, 6, 4]
-    public let brand: String = CreditCardBrands.dinersClubInternational
+    public let brand: CreditCardBrand = .dinersClubInternational
     
     private let maxLength = 19
     private let minLength = 14

--- a/Sources/CreditCardFormatter/Formats/DiscoverCreditCardFormat.swift
+++ b/Sources/CreditCardFormatter/Formats/DiscoverCreditCardFormat.swift
@@ -26,13 +26,9 @@
 
 import Foundation
 
-public extension CreditCardBrands {
-    static let discover = "Discover"
-}
-
 public struct DiscoverCreditCardFormat: CreditCardFormat {
     public let blocks: [Int] = [4, 4, 4, 4, 3]
-    public let brand: String = CreditCardBrands.discover
+    public let brand: CreditCardBrand = .discover
     
     private let maxLength = 19
     private let minLength = 16

--- a/Sources/CreditCardFormatter/Formats/DiscoverCreditCardFormat.swift
+++ b/Sources/CreditCardFormatter/Formats/DiscoverCreditCardFormat.swift
@@ -29,6 +29,7 @@ import Foundation
 public struct DiscoverCreditCardFormat: CreditCardFormat {
     public let blocks: [Int] = [4, 4, 4, 4, 3]
     public let brand: CreditCardBrand = .discover
+    public let cvvLength: Int = 3
     
     private let maxLength = 19
     private let minLength = 16

--- a/Sources/CreditCardFormatter/Formats/JCBCreditCardFormat.swift
+++ b/Sources/CreditCardFormatter/Formats/JCBCreditCardFormat.swift
@@ -26,13 +26,9 @@
 
 import Foundation
 
-public extension CreditCardBrands {
-    static let jcb = "JCB"
-}
-
 public struct JCBCreditCardFormat: CreditCardFormat {
     public let blocks: [Int] = [4, 4, 4, 4, 3]
-    public let brand: String = CreditCardBrands.jcb
+    public let brand: CreditCardBrand = .jcb
     
     private let maxLength = 19
     private let minLength = 16

--- a/Sources/CreditCardFormatter/Formats/JCBCreditCardFormat.swift
+++ b/Sources/CreditCardFormatter/Formats/JCBCreditCardFormat.swift
@@ -29,6 +29,7 @@ import Foundation
 public struct JCBCreditCardFormat: CreditCardFormat {
     public let blocks: [Int] = [4, 4, 4, 4, 3]
     public let brand: CreditCardBrand = .jcb
+    public let cvvLength: Int = 3
     
     private let maxLength = 19
     private let minLength = 16

--- a/Sources/CreditCardFormatter/Formats/MasterCardCreditCardFormat.swift
+++ b/Sources/CreditCardFormatter/Formats/MasterCardCreditCardFormat.swift
@@ -29,6 +29,7 @@ import Foundation
 public struct MasterCardCreditCardFormat: CreditCardFormat {
     public let blocks: [Int] = [4, 4, 4, 4]
     public let brand: CreditCardBrand = .masterCard
+    public let cvvLength: Int = 3
     
     public init() {}
     

--- a/Sources/CreditCardFormatter/Formats/MasterCardCreditCardFormat.swift
+++ b/Sources/CreditCardFormatter/Formats/MasterCardCreditCardFormat.swift
@@ -26,13 +26,9 @@
 
 import Foundation
 
-public extension CreditCardBrands {
-    static let masterCard = "Master Card"
-}
-
 public struct MasterCardCreditCardFormat: CreditCardFormat {
     public let blocks: [Int] = [4, 4, 4, 4]
-    public let brand: String = CreditCardBrands.masterCard
+    public let brand: CreditCardBrand = .masterCard
     
     public init() {}
     

--- a/Sources/CreditCardFormatter/Formats/UnknownCreditCardFormat.swift
+++ b/Sources/CreditCardFormatter/Formats/UnknownCreditCardFormat.swift
@@ -26,13 +26,9 @@
 
 import Foundation
 
-public enum CreditCardBrands {
-    public static let unknown = "Unknown"
-}
-
 struct UnknownCreditCardFormat: CreditCardFormat {
     public let blocks: [Int] = [4]
-    public let brand: String = CreditCardBrands.unknown
+    public let brand: CreditCardBrand = .unknown
 
     public init() {}
 

--- a/Sources/CreditCardFormatter/Formats/UnknownCreditCardFormat.swift
+++ b/Sources/CreditCardFormatter/Formats/UnknownCreditCardFormat.swift
@@ -29,7 +29,8 @@ import Foundation
 struct UnknownCreditCardFormat: CreditCardFormat {
     public let blocks: [Int] = [4]
     public let brand: CreditCardBrand = .unknown
-
+    public let cvvLength: Int = 4
+    
     public init() {}
 
     public func shouldFormat(_ string: String) -> Bool {

--- a/Sources/CreditCardFormatter/Formats/VISACreditCardFormat.swift
+++ b/Sources/CreditCardFormatter/Formats/VISACreditCardFormat.swift
@@ -26,13 +26,9 @@
 
 import Foundation
 
-public extension CreditCardBrands {
-    static let visa = "VISA"
-}
-
 public struct VISACreditCardFormat: CreditCardFormat {
     public let blocks: [Int] = [4, 4, 4, 4]
-    public let brand: String = CreditCardBrands.visa
+    public let brand: CreditCardBrand = .visa
 
     public init() {}
 

--- a/Sources/CreditCardFormatter/Formats/VISACreditCardFormat.swift
+++ b/Sources/CreditCardFormatter/Formats/VISACreditCardFormat.swift
@@ -29,7 +29,8 @@ import Foundation
 public struct VISACreditCardFormat: CreditCardFormat {
     public let blocks: [Int] = [4, 4, 4, 4]
     public let brand: CreditCardBrand = .visa
-
+    public let cvvLength: Int = 3
+    
     public init() {}
 
     public func shouldFormat(_ string: String) -> Bool {


### PR DESCRIPTION
# Added Feature Description
- This development allows masked credit card numbers to be formatted.

# Example
**Masked Card Number Input:** _"123456****1008"_
**Formatted Card Number Output:** _"1234 56 **** 1008"_